### PR TITLE
DRF friendship

### DIFF
--- a/api/models.py
+++ b/api/models.py
@@ -59,5 +59,5 @@ class Media(models.Model):
         # TODO: auto detect media_service
         if self.media_service is None:  # Set default reference
             self.media_service = MediaService.objects.get(id=1)
-        super.save(*args, **kwargs)
+        super().save(*args, **kwargs)
 

--- a/api/permissions.py
+++ b/api/permissions.py
@@ -31,6 +31,28 @@ class IsFriendsQueue(permissions.BasePermission):
     """
 
     def has_object_permission(self, request, view, obj):
+        friends = are_friends(request.user, obj.owner.user)
+        return friends and obj.privacy == Queue.PUBLIC
+
+
+class IsPublicMedia(permissions.BasePermission):
+    def has_object_permission(self, request, view, obj):
+        # Any permission is only allowed to the queues's owner.
+        return obj.queue.privacy == Queue.PUBLIC
+
+
+class IsFriendsMedia(permissions.BasePermission):
+    def has_object_permission(self, request, view, obj):
+        friends = are_friends(request.user, obj.queue.owner.user)
+        return friends
+
+
+class IsFriendsQueue(permissions.BasePermission):
+    """
+    Object-level permission to allow a user to see a friend's public queue.
+    """
+
+    def has_object_permission(self, request, view, obj):
         # Any permission is only allowed to the queues's owner.
         friends = are_friends(request.user, obj.owner.user)
         return friends and obj.privacy == Queue.PUBLIC

--- a/api/permissions.py
+++ b/api/permissions.py
@@ -1,5 +1,8 @@
 from rest_framework import permissions
 
+from api.models import Queue
+from api.utils import are_friends
+
 
 class IsMediaOwner(permissions.BasePermission):
     """
@@ -10,3 +13,35 @@ class IsMediaOwner(permissions.BasePermission):
     def has_object_permission(self, request, view, obj):
         # Any permission is only allowed to the media's owner.
         return obj.queue.owner.user == request.user
+
+
+class IsQueueOwner(permissions.BasePermission):
+    """
+    Object-level permission to only allow owners of an queue to view it.
+    """
+
+    def has_object_permission(self, request, view, obj):
+        # Any permission is only allowed to the queues's owner.
+        return obj.owner.user == request.user
+
+
+class IsFriendsQueue(permissions.BasePermission):
+    """
+    Object-level permission to allow a user to see a friend's public queue.
+    """
+
+    def has_object_permission(self, request, view, obj):
+        # Any permission is only allowed to the queues's owner.
+        friends = are_friends(request.user, obj.owner.user)
+        return friends and obj.privacy == Queue.PUBLIC
+
+
+class IsReadOnly(permissions.BasePermission):
+    """
+    Object-level permission to only allow SAFE methods.
+    """
+
+    def has_object_permission(self, request, view, obj):
+        # Read permissions are allowed to any request,
+        # so we'll always allow GET, HEAD or OPTIONS requests.
+        return request.method in permissions.SAFE_METHODS

--- a/api/serializers.py
+++ b/api/serializers.py
@@ -1,31 +1,69 @@
 from django.contrib.auth.models import User as DjangoUser
 
 from rest_framework import serializers
+from rest_framework.fields import CurrentUserDefault
+
+from userena.utils import get_user_profile
 
 from api.models import User, Queue, Media, MediaService
+from api.permissions import IsQueueOwner, IsFriendsQueue
+from api.utils import are_friends
 
 
-class QueueListSerializer(serializers.ListSerializer):
-    def to_representation(self, data):
-        data = data.filter(privacy=Queue.PUBLIC)
-        print(data)
-        return super().to_representation(data)
+
+class DynamicFieldsModelSerializer(serializers.ModelSerializer):
+    """
+    A ModelSerializer that takes an additional `fields` argument that
+    controls which fields should be displayed.
+    Source: http://www.django-rest-framework.org/api-guide/serializers/#dynamically-modifying-fields
+    """
+
+    def __init__(self, *args, **kwargs):
+        # Don't pass the 'fields' arg up to the superclass
+        fields = kwargs.pop('fields', None)
+
+        # Instantiate the superclass normally
+        super().__init__(*args, **kwargs)
+
+        if fields is not None:
+            # Drop any fields that are not specified in the `fields` argument.
+            allowed = set(fields)
+            existing = set(self.fields.keys())
+            for field_name in existing - allowed:
+                self.fields.pop(field_name)
 
 
-class QueueSerializer(serializers.HyperlinkedModelSerializer):
+class QueueSerializer(DynamicFieldsModelSerializer, serializers.HyperlinkedModelSerializer):
     owner = serializers.HyperlinkedRelatedField(read_only=True, view_name='user-detail', lookup_field='username')
     medias = serializers.HyperlinkedRelatedField(many=True, read_only=True, view_name='media-detail')
 
     class Meta:
         model = Queue
-        #list_serializer_class = QueueListSerializer
         fields = ('url', 'owner', 'name', 'medias', 'privacy')
 
 
 class UserSerializer(serializers.HyperlinkedModelSerializer):
     url = serializers.HyperlinkedIdentityField(view_name='user-detail', lookup_field='username')
     username = serializers.ReadOnlyField(source='user.username')
-    # queues = QueueSerializer(read_only=True, many=True)
+    queues = serializers.SerializerMethodField()
+
+    def get_queues(self, user):
+        curr_user = None
+
+        request = self.context.get("request")
+        if request and hasattr(request, "user"):
+            curr_user = request.user
+
+        qs = Queue.objects.none()
+        if user.user == curr_user:
+            # Is the owner
+            qs = user.queues.all()
+        elif are_friends(user.user, curr_user):
+            # Are friends, only show Public Queues
+            qs = user.queues.filter(privacy=Queue.PUBLIC)
+        
+        serializer = QueueSerializer(instance=qs, read_only=True, many=True, context=self.context, fields=['url', 'name'])
+        return serializer.data
 
     class Meta:
         model = User

--- a/api/serializers.py
+++ b/api/serializers.py
@@ -5,20 +5,31 @@ from rest_framework import serializers
 from api.models import User, Queue, Media, MediaService
 
 
+class QueueListSerializer(serializers.ListSerializer):
+    def to_representation(self, data):
+        data = data.filter(privacy=Queue.PUBLIC)
+        print(data)
+        return super().to_representation(data)
+
+
 class QueueSerializer(serializers.HyperlinkedModelSerializer):
     owner = serializers.HyperlinkedRelatedField(read_only=True, view_name='user-detail', lookup_field='username')
     medias = serializers.HyperlinkedRelatedField(many=True, read_only=True, view_name='media-detail')
 
     class Meta:
         model = Queue
+        #list_serializer_class = QueueListSerializer
         fields = ('url', 'owner', 'name', 'medias', 'privacy')
 
+
 class UserSerializer(serializers.HyperlinkedModelSerializer):
+    url = serializers.HyperlinkedIdentityField(view_name='user-detail', lookup_field='username')
     username = serializers.ReadOnlyField(source='user.username')
+    # queues = QueueSerializer(read_only=True, many=True)
 
     class Meta:
         model = User
-        fields = ('username', 'queues')
+        fields = ('url', 'username', 'queues')
 
 class MediaSerializer(serializers.HyperlinkedModelSerializer):
     # TODO: filter user's queues

--- a/api/utils.py
+++ b/api/utils.py
@@ -1,3 +1,5 @@
+from friendship.models import Friend
+
 from userena.utils import get_user_profile
 
 def get_users_profiles(users):
@@ -7,3 +9,6 @@ def get_users_profiles(users):
     """
     users_profiles = [get_user_profile(user) for user in users]
     return users_profiles
+
+def are_friends(user_from, user_to):
+    return Friend.objects.are_friends(user_from, user_to)

--- a/api/utils.py
+++ b/api/utils.py
@@ -1,0 +1,9 @@
+from userena.utils import get_user_profile
+
+def get_users_profiles(users):
+    """
+        Gets the User profile associated to each of
+        the django-userena's users on $users
+    """
+    users_profiles = [get_user_profile(user) for user in users]
+    return users_profiles

--- a/api/views.py
+++ b/api/views.py
@@ -15,7 +15,7 @@ from friendship.models import Friend
 
 from api.models import User, Queue, Media
 from api.serializers import UserSerializer, QueueSerializer, MediaSerializer
-from api.permissions import IsMediaOwner, IsQueueOwner, IsFriendsQueue, IsReadOnly
+from api.permissions import *
 from api.utils import get_users_profiles
 
 # TODO Configure UserViewSet
@@ -62,12 +62,17 @@ class QueueViewSet(viewsets.ModelViewSet):
 class MediaViewSet(viewsets.ModelViewSet):
     queryset = Media.objects.none()
     serializer_class = MediaSerializer
-    permission_classes = (IsAuthenticated, IsMediaOwner)
+    permission_classes = (IsAuthenticated, Or(IsMediaOwner, And(IsFriendsMedia, IsPublicMedia, IsReadOnly)))
 
     def get_queryset(self):
         user = self.request.user
         return Media.objects.filter(queue__owner__user=user)
 
+    def get_object(self):
+        obj = get_object_or_404(Media, pk=self.kwargs.get('pk'))
+        self.check_object_permissions(self.request, obj)
+        return obj
+        
 
 class FriendViewSet(viewsets.ModelViewSet):
     queryset = User.objects.none()

--- a/enqueuer_api/urls.py
+++ b/enqueuer_api/urls.py
@@ -24,6 +24,7 @@ router = DefaultRouter()
 #router.register(r'users', views.UserDetail)
 router.register(r'queues', views.QueueViewSet)
 router.register(r'medias', views.MediaViewSet)
+router.register(r'friends', views.FriendViewSet)
 
 urlpatterns = [
     url(r'^', include(router.urls)),
@@ -31,4 +32,5 @@ urlpatterns = [
     url(r'^auth/', include('rest_framework.urls')),
     url(r'^admin/', admin.site.urls),
     url(r'^accounts/', include('userena.urls')),
+#    url(r'^friendship/', include('friendship.urls')),
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,5 +9,6 @@ gunicorn==19.6.0
 html2text==2014.12.29
 Pillow==3.4.1
 psycopg2==2.6.2
+rest-condition==1.0.2
 six==1.10.0
 whitenoise==3.2.2


### PR DESCRIPTION
Implements basic friends view and related stuff.
- Integrates **django-userena**, **django-friendship** and **DRF** (#3). 
- Adds Queues permissions (#5). Checks for queue's owner and friend's public queues.
- Adds partial Media's permissions (#22). A user can see a friend's public media (a media on a user's public queue). Media's creation is still wrong. Any user can add any media to any queue.
